### PR TITLE
fix ascii characters to new click version

### DIFF
--- a/click_help_colors/__init__.py
+++ b/click_help_colors/__init__.py
@@ -6,7 +6,7 @@ def _colorize(text, color=None):
     if not color:
         return text
     try:
-        return '\033[%dm' % (_ansi_colors.index(color) + 30) + text + _ansi_reset_all
+        return '\033[%dm' % (_ansi_colors[color]) + text + _ansi_reset_all
     except ValueError:
         raise TypeError('Unknown color %r' % color)
 


### PR DESCRIPTION
Click upcoming 7.0 release.

```py
>>> from click.termui import _ansi_colors
>>> _ansi_colors.index
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'dict' object has no attribute 'index'
>>> _ansi_colors
{'black': 30, 'red': 31, 'green': 32, 'yellow': 33, 'blue': 34, 'magenta': 35, 'cyan': 36, 'white': 37, 'reset': 39, 'bright_black': 90, 'bright_red': 91, 'bright_green': 92, 'bright_yellow': 93, 'bright_blue': 94, 'bright_magenta': 95, 'bright_cyan': 96, 'bright_white': 97}
```