### PR TITLE
Fix issue with options with multiple names

### DIFF
--- a/tests/test_custom_colors.py
+++ b/tests/test_custom_colors.py
@@ -1,3 +1,4 @@
+import pytest
 import click
 
 from click_help_colors import HelpColorsGroup, HelpColorsCommand
@@ -61,4 +62,84 @@ def test_custom_option_color(runner):
         '\x1b[33mCommands\x1b[0m:',
         '  \x1b[31mcommand1\x1b[0m',
         '  \x1b[32mcommand2\x1b[0m'
+    ]
+
+
+def test_option_color(runner):
+    @click.group(
+        cls=HelpColorsGroup,
+        help_headers_color='yellow',
+        help_options_color='green',
+        help_options_custom_colors={'--name': 'red'}
+    )
+    def cli():
+        pass
+
+    @cli.command()
+    @click.option('--name', help='The person to greet.')
+    def command(name):
+        pass
+
+    result = runner.invoke(cli, ['command', '--help'], color=True)
+    assert not result.exception
+    assert result.output.splitlines() == [
+        '\x1b[33mUsage: \x1b[0mcli command [OPTIONS]',
+        '',
+        '\x1b[33mOptions\x1b[0m:',
+        '  \x1b[31m--name TEXT\x1b[0m  The person to greet.',
+        '  \x1b[32m--help\x1b[0m       Show this message and exit.'
+    ]
+
+
+@pytest.mark.parametrize('option_name', ['-n', '--name', '-n,'])
+def test_multi_name_option_color(runner, option_name):
+    @click.group(
+        cls=HelpColorsGroup,
+        help_headers_color='yellow',
+        help_options_color='green',
+        help_options_custom_colors={option_name: 'red'}
+    )
+    def cli():
+        pass
+
+    @cli.command()
+    @click.option('-n', '--name', help='The person to greet.')
+    def command(name):
+        pass
+
+    result = runner.invoke(cli, ['command', '--help'], color=True)
+    assert not result.exception
+    assert result.output.splitlines() == [
+        '\x1b[33mUsage: \x1b[0mcli command [OPTIONS]',
+        '',
+        '\x1b[33mOptions\x1b[0m:',
+        '  \x1b[31m-n, --name TEXT\x1b[0m  The person to greet.',
+        '  \x1b[32m--help\x1b[0m           Show this message and exit.'
+    ]
+
+
+@pytest.mark.parametrize('option_name', ['--shout', '--no-shout'])
+def test_flag_option_color(runner, option_name):
+    @click.group(
+        cls=HelpColorsGroup,
+        help_headers_color='yellow',
+        help_options_color='green',
+        help_options_custom_colors={option_name: 'red'}
+    )
+    def cli():
+        pass
+
+    @cli.command()
+    @click.option('--shout/--no-shout', default=False)
+    def command(name):
+        pass
+
+    result = runner.invoke(cli, ['command', '--help'], color=True)
+    assert not result.exception
+    assert result.output.splitlines() == [
+        '\x1b[33mUsage: \x1b[0mcli command [OPTIONS]',
+        '',
+        '\x1b[33mOptions\x1b[0m:',
+        '  \x1b[31m--shout / --no-shout\x1b[0m',
+        '  \x1b[32m--help\x1b[0m                Show this message and exit.'
     ]


### PR DESCRIPTION
Hi, I found an issues with options that have multiple names. For example if the options has `-n` and `--name` in order to change the color of this options you will need to pass `-n,` to `help_options_custom_colors`.

```python
@click.group(
    cls=HelpColorsGroup,
    help_headers_color='yellow',
    help_options_color='green',
    help_options_custom_colors={'-n,': 'red'}
)
def cli():
    pass

@cli.command()
@click.option('-n', '--name', help='The person to greet.')
def command(name):
    pass
```

The fix will allow `-n`, `--name` and `-n,` to work with `help_options_custom_colors`.
