### PR TITLE
Enable ANSI color when `NO_COLOR` is an empty string

### DIFF
--- a/click_help_colors/utils.py
+++ b/click_help_colors/utils.py
@@ -8,7 +8,7 @@ class HelpColorsException(Exception):
 
 
 def _colorize(text, color=None, suffix=None):
-    if not color or "NO_COLOR" in os.environ:
+    if not color or os.getenv("NO_COLOR"):
         return text + (suffix or '')
     try:
         return '\033[%dm' % (_ansi_colors[color]) + text + \


### PR DESCRIPTION
The [`NO_COLOR` standard](https://no-color.org/) specifies that color should not be prevented when the `NO_COLOR` environment variable is an empty string:

> Command-line software which adds ANSI color to its output by default should check for a `NO_COLOR` environment variable that, when present **and not an empty string** (regardless of its value), prevents the addition of ANSI color.

This behavior is not reflected by **click-help-colors**, which will incorrectly remove colors when `NO_COLOR=''`. This PR fixes this issue.