### PR TITLE
Add `py.typed` to package data in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     name='click-help-colors',
     version=version,
     packages=['click_help_colors'],
+    package_data={'click_help_colors': ['py.typed']},
     description='Colorization of help messages in Click',
     long_description=readme,
     url='https://github.com/click-contrib/click-help-colors',
@@ -29,5 +30,5 @@ setup(
             "mypy",
             "pytest",
         ]
-    }
+    },
 )


### PR DESCRIPTION
Well this is embarrassing.

When submitting #22, I added `py.typed` to MANIFEST.in, but I forgot to include it in setup.py. As a result, `mypy` does not detect type hints, and #20 is still not fixed. This PR added `py.typed` to setup.py.
Once this PR is merged and a new version of `click-help-colors` is published, #20 will finally be fixed (for real this time).