### PR TITLE
Fix running the test suite when NO_COLOR is set in calling env

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 import click
@@ -7,3 +9,12 @@ from click.testing import CliRunner
 @pytest.fixture
 def runner():
     return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def clean_env():
+    old = dict(os.environ)
+    os.environ.pop("FORCE_COLOR", None)
+    os.environ.pop("NO_COLOR", None)
+    yield
+    os.environ = old


### PR DESCRIPTION
Fix the test suite to run successfully when NO_COLOR is set in the environment in which pytest is called.  This is done via adding a new fixture that "sanitizes" the environment for the duration of test run.  This way pytest respects NO_COLOR while the tested library itself produces colored output as expected.